### PR TITLE
do not put method (https/ssh) into URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bibliography"]
 	path = bibliography
-	url = git@github.com:the-teachingRSE-project/bibliography.git
+	url = ../bibliography.git


### PR DESCRIPTION
do not put method (https/ssh) into URL for submodule; use relative path instead which will choose the method used for the main repo