### PR TITLE
Update affiliation GC

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,6 +159,7 @@ authors:
     initials: GC
     affiliations:
       - School of Computation, Information and Technology, Technical University of Munich, Garching, Germany
+      - Institute for Parallel and Distributed Systems, University of Stuttgart, Stuttgart, Germany
     orcid: 0000-0002-3977-1385
     email: gerasimos.chourdakis@tum.de
 


### PR DESCRIPTION
When I first joined (September 2023), and till March 2024, I was employed by the Technical University of Munich.
Since April 2024, I am employed by the University of Stuttgart.

Since there are significant time intervals in both universities, I feel like both should be listed here.

The pagination was already broken before, and I think we should not worry about it outside the published versions. For the arXiv preprint, we can still work around with the margins, if we want to keep the keywords in the first page. For the peer-reviewed version, there will anyway be a different template.

We could also drop the specific institutes (e.g., me and @jngrad are now in different institutes in the same university) and merge the affiliations at the universities/organizations level.