### PR TITLE
Fit table of contents into one page

### DIFF
--- a/competencies.md
+++ b/competencies.md
@@ -85,7 +85,7 @@ include-after:
   - \printglossary[type=\acronymtype]
 xnos-cleveref: True
 xnos-capitalise: True
-toc-baselinestretch: 0.95
+toc-baselinestretch: 0.85
 keywords:
   - research software engineering
   - RSE


### PR DESCRIPTION
We already have a parameter for the margins in the ToC. Relaxing it a bit fits the ToC in one page.

Related to #356.

(two PRs, because the title page is more complicated)