### PR TITLE
Fit title page in one page

### DIFF
--- a/competencies.md
+++ b/competencies.md
@@ -1,6 +1,6 @@
 ---
 title: "Foundational Competencies and Responsibilities of a Research Software Engineer"
-geometry: margin=2.5cm
+geometry: "top=0.5cm,right=2.5cm,bottom=2.5cm,left=2.5cm" # Only for the title page, see include-before for the rest.
 author:
   - Florian Goth | Corresponding author
   - Renato Alves
@@ -79,6 +79,7 @@ header-includes:
   - \newglossaryentry{USERS}{name={\USERS},type={skills},description={Interaction with users and other stakeholders}}
 include-before:
   - \newpage
+  - \newgeometry{top=2.5cm,right=2.5cm,bottom=2.5cm,left=2.5cm}
 include-after:
   - \printglossary
   - \printglossary[type=skills]


### PR DESCRIPTION
Related to #356 (more might come at the end of the manuscript, after merging #350).

We don't explicitly call `\maketitle` anywhere (pandoc does this for us), so changing the margins specifically for the titlepage is... complicated. My hacky solution was to set the general geometry to what we want the title page to have, and then update the geometry in the main content.

![Screenshot from 2024-08-12 13-46-08](https://github.com/user-attachments/assets/afc3f773-c192-4e30-b4af-73ca34da3b4f)
