### PR TITLE
Fix summarised_competencies CI issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 competencies.pdf
-summarized_competencies.pdf
+summarised_competencies.pdf
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-call_to_action.pdf
 competencies.pdf
-institutionalised_education.pdf
-intro.pdf
-survey.pdf
+summarized_competencies.pdf
 build/

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,7 +253,7 @@ authors:
     firstName: teachingRSE
     lastName: Project
     suffixName: the
-    initials: tRSE
+    initials: We
     affiliations:
       - University of Würzburg
     orcid: 0000-0000-0000-0000

--- a/contributors.yml
+++ b/contributors.yml
@@ -255,7 +255,7 @@ authors:
     suffixName: the
     initials: We
     affiliations:
-      - University of Würzburg
+      - \url{https://github.com/the-teachingRSE-project}
     orcid: 0000-0000-0000-0000
     email: teachingrse@lists.uni-wuerzburg.de
     acknowledgements: |

--- a/summarised_competencies.md
+++ b/summarised_competencies.md
@@ -2,33 +2,30 @@
 title: "Foundational Competencies and Responsibilities of a Research Software Engineer - A summary"
 geometry: "top=0.5cm,right=2.5cm,bottom=2.5cm,left=2.5cm" # Only for the title page, see include-before for the rest.
 author:
- <!---
-  - Florian Goth | Corresponding author
-  - Renato Alves
-  - Matthias Braun
-  - Leyla Jael Castro
-  - Gerasimos Chourdakis
-  - Simon Christ
-  - Jeremy Cohen
-  - Stephan Druskat
-  - Fredo Erxleben
-  - Jean-Noël Grad
-  - Magnus Hagdorn
-  - Toby Hodges
-  - Guido Juckeland
-  - Dominic Kempf
-  - Anna-Lena Lamprecht
-  - Jan Linxweiler
-  - Frank Löffler
-  - Michele Martone
-  - Moritz Schwarzmeier
-  - Heidi Seibold
-  - Jan Philipp Thiele
-  - Harald von Waldow
-  - Samantha Wittke
- --->
-
-  - the teachingRSE project
+  - The teachingRSE project
+#  - Florian Goth | Corresponding author
+#  - Renato Alves
+#  - Matthias Braun
+#  - Leyla Jael Castro
+#  - Gerasimos Chourdakis
+#  - Simon Christ
+#  - Jeremy Cohen
+#  - Stephan Druskat
+#  - Fredo Erxleben
+#  - Jean-Noël Grad
+#  - Magnus Hagdorn
+#  - Toby Hodges
+#  - Guido Juckeland
+#  - Dominic Kempf
+#  - Anna-Lena Lamprecht
+#  - Jan Linxweiler
+#  - Frank Löffler
+#  - Michele Martone
+#  - Moritz Schwarzmeier
+#  - Heidi Seibold
+#  - Jan Philipp Thiele
+#  - Harald von Waldow
+#  - Samantha Wittke
 
 output:
   pdf_document:

--- a/summarised_competencies.md
+++ b/summarised_competencies.md
@@ -3,29 +3,6 @@ title: "Foundational Competencies and Responsibilities of a Research Software En
 geometry: "top=0.5cm,right=2.5cm,bottom=2.5cm,left=2.5cm" # Only for the title page, see include-before for the rest.
 author:
   - The teachingRSE project
-#  - Florian Goth | Corresponding author
-#  - Renato Alves
-#  - Matthias Braun
-#  - Leyla Jael Castro
-#  - Gerasimos Chourdakis
-#  - Simon Christ
-#  - Jeremy Cohen
-#  - Stephan Druskat
-#  - Fredo Erxleben
-#  - Jean-Noël Grad
-#  - Magnus Hagdorn
-#  - Toby Hodges
-#  - Guido Juckeland
-#  - Dominic Kempf
-#  - Anna-Lena Lamprecht
-#  - Jan Linxweiler
-#  - Frank Löffler
-#  - Michele Martone
-#  - Moritz Schwarzmeier
-#  - Heidi Seibold
-#  - Jan Philipp Thiele
-#  - Harald von Waldow
-#  - Samantha Wittke
 
 output:
   pdf_document:


### PR DESCRIPTION
In the `summarized_competencies.md`:

- Removes the duplicate commented-out list of authors (the comment needs to be in YAML anyway)
- Replaces "University of Würzburg" with `https://github.com/the-teachingRSE-project` as affiliation.
- Fix an assertion regarding the initials not appearing in the acknowledgments list (replaces it with `We`, renders normally)
- Update the `.gitignore`

Motivated by the CI failing for the pull request #362 (not for the branch, but for the merged result).