### PR TITLE
Fix CI: Create a Python venv

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,7 +19,7 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra lmodern fonts-linuxlibertine \
             python3 python3-yaml \
             xz-utils make sed gpg-agent
-          python3 -m venv ${{ env.DIR }}/venv && source ${{ env.DIR }}/bin/activate
+          python3 -m venv ${{ env.DIR }}/venv && source ${{ env.DIR }}/venv/bin/activate
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
           # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
           python3 -m pip install --force-reinstall git+https://github.com/tomduck/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,7 +2,7 @@ name: compilepaper
 on: [push, pull_request]
 jobs:
   paper:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       DIR: .
     steps:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,6 +19,7 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra lmodern fonts-linuxlibertine \
             python3 python3-yaml \
             xz-utils make sed gpg-agent
+          python -m venv . && source ./bin/activate
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
       - name: Fetch bibliography
         run : |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,8 +19,10 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra lmodern fonts-linuxlibertine \
             python3 python3-yaml \
             xz-utils make sed gpg-agent
-          python -m venv ${{ env.DIR }} && source ${{ env.DIR }}/bin/activate
+          python3 -m venv ${{ env.DIR }} && source ${{ env.DIR }}/bin/activate
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
+          # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
+          python3 -m pip install --force-reinstall git+https://github.com/tomduck/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos
       - name: Fetch bibliography
         run : |
           # resolve relative paths in forked projects

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,7 +19,7 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra lmodern fonts-linuxlibertine \
             python3 python3-yaml \
             xz-utils make sed gpg-agent
-          python3 -m venv ${{ env.DIR }} && source ${{ env.DIR }}/bin/activate
+          python3 -m venv ${{ env.DIR }}/venv && source ${{ env.DIR }}/bin/activate
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
           # Workaround for https://github.com/tomduck/pandoc-xnos/pull/29
           python3 -m pip install --force-reinstall git+https://github.com/tomduck/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos
@@ -31,7 +31,7 @@ jobs:
           git config --local submodule.recurse true
       - name: pandoc compile
         working-directory: ${{ env.DIR }}
-        run: source ${{ env.DIR }}/bin/activate && make all
+        run: source ${{ env.DIR }}/venv/bin/activate && make all
       - name: move
         run: mkdir -p github_artifacts && mv ${{ env.DIR }}/*.pdf ./github_artifacts/
       - name: Upload pdf as artifact

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,7 +19,7 @@ jobs:
             texlive-fonts-recommended texlive-fonts-extra lmodern fonts-linuxlibertine \
             python3 python3-yaml \
             xz-utils make sed gpg-agent
-          python -m venv . && source ./bin/activate
+          python -m venv ${{ env.DIR }} && source ${{ env.DIR }}/bin/activate
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
       - name: Fetch bibliography
         run : |
@@ -29,7 +29,7 @@ jobs:
           git config --local submodule.recurse true
       - name: pandoc compile
         working-directory: ${{ env.DIR }}
-        run: make all
+        run: source ${{ env.DIR }}/bin/activate && make all
       - name: move
         run: mkdir -p github_artifacts && mv ${{ env.DIR }}/*.pdf ./github_artifacts/
       - name: Upload pdf as artifact


### PR DESCRIPTION
Our CI is based on `ubuntu-latest`. I assume this was recently switched to Ubuntu 24.04, which does not allow pip installations outside a virtual environment.

This creates a venv before installing the Python requirements.