### PR TITLE
add CITATION.cff rewriting

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -236,7 +236,7 @@ authors:
     lastName: Löffler
     initials: FL
     affiliations:
-      - Michael Stifel Center Jena \& Friedrich Schiller University Jena, Germany
+      - Michael Stifel Center Jena & Friedrich Schiller University Jena, Germany
     orcid: 0000-0001-6643-6323
     email: frank.loeffler@uni-jena.de
 

--- a/filter.py
+++ b/filter.py
@@ -5,6 +5,7 @@ with full author information (name, affiliation(s), ORCID iD).
 Add funding acknowledgements at the bottom of the manuscript.
 """
 
+import sys, re
 import yaml
 import argparse
 
@@ -16,6 +17,9 @@ parser.add_argument("--output", type=str, required=False,
 parser.add_argument("--contributors", type=str, required=False,
                     default="contributors.yml",
                     help="contributors YAML file")
+parser.add_argument("--cff", type=str, required=False,
+                    default=None,
+                    help="CITATION.cff CFF file")
 
 
 def get_contributors_metadata(content):
@@ -46,6 +50,7 @@ def get_author_thanks(metadata):
 def process_markdown(metadata, body, contributors):
     authors_tex = []
     authors_xmp = []
+    authors_cff = []
     affiliations = {}
     acknowledgements = ["# Acknowledgements {- #sec:acknowledgements}"]
     bookkeeping_initials = {}
@@ -58,8 +63,13 @@ def process_markdown(metadata, body, contributors):
         author_metadata = contributors[fullname]
         authors_xmp.append(fullname)
         author_tex = fullname
+        author_cff = {'given-names': author_metadata['firstName'],
+                      'family-names': author_metadata['lastName'],}
         if "orcid" in author_metadata:
             author_tex += f"\\texorpdfstring{{\\thinspace\\orcidlink{{{author_metadata['orcid']}}}}}{{}}"
+            author_cff['orcid'] = r'https://orcid.org/' + author_metadata['orcid']
+        if "email" in author_metadata:
+            author_cff['email'] = author_metadata['email']
         author_affil = []
         if annotations:
             author_affil.append("")
@@ -69,7 +79,12 @@ def process_markdown(metadata, body, contributors):
             if affiliation not in affiliations:
                 affiliations[affiliation] = f"{len(affiliations) + 1}"
             author_affil.append(affiliations[affiliation])
+            if 'affiliation' not in author_cff:
+                author_cff['affiliation'] = affiliation
+            else:
+                author_cff['affiliation'] += '; ' + affiliation
         authors_tex.append(f"\\author[{','.join(author_affil)}]{{{author_tex}}}")
+        authors_cff.append(author_cff)
         initials = author_metadata["initials"]
         assert initials not in bookkeeping_initials, f"initials '{initials}' collide with '{fullname}' and '{bookkeeping_initials[initials]}'"
         bookkeeping_initials[initials] = fullname
@@ -77,7 +92,7 @@ def process_markdown(metadata, body, contributors):
             message = author_metadata["acknowledgements"]
             assert initials in message, f"'{initials}' doesn't appear in the acknowledgements of '{fullname}'"
             acknowledgements.append(message)
-    affiliations_tex = [f"\\affil[{key}]{{{affil}}}" for affil, key in affiliations.items()]
+    affiliations_tex = [f"\\affil[{key}]{{"+affil.replace('&',r'\&')+"}" for affil, key in affiliations.items()]
     if "acknowledgements-after" in metadata:
         acknowledgements.append(metadata["acknowledgements-after"])
         del metadata["acknowledgements-after"]
@@ -99,7 +114,7 @@ def process_markdown(metadata, body, contributors):
         markdown.append(body)
         markdown.append("")
         markdown.extend(acknowledgements)
-    return "\n".join(markdown)
+    return ("\n".join(markdown), yaml.dump(authors_cff, allow_unicode=True, sort_keys=False))
 
 
 if __name__ == "__main__":
@@ -108,11 +123,26 @@ if __name__ == "__main__":
         contributors = get_contributors_metadata(f.read())
     with open(args.input) as f:
         metadata, body = get_manuscript_metadata(f.read())
+    if args.cff:
+        with open(args.cff, "r") as f:
+            # Do not use a yaml library here to avoid changing any of the formatting of what we
+            # do not want to touch. Instead, split by looking for the 'authors'-Block
+            cff_orig = f.read()
+            cff_parts = re.split(r'authors:\n(?:-? +[^\n]+\n)+', cff_orig)
+            if len(cff_parts) != 2:
+                print(f'Could not properly parse {args.cff}')
+                sys.exit(1)
     for key in get_author_thanks(metadata).keys():
         assert key in contributors, f"author '{key}' in {args.input} not found in {args.contributors}"
-    markdown = process_markdown(metadata, body, contributors)
+    (markdown, cff_authors) = process_markdown(metadata, body, contributors)
     if args.output:
         with open(args.output, "w") as f:
             f.write(markdown)
     else:
         print(markdown)
+    if args.cff:
+        with open(args.cff, "w") as f:
+            f.write(cff_parts[0])
+            # prepend two spaces: not necessary for yaml, but simulates what cffinit does
+            f.write('authors:\n' + re.sub(r'(.+)', r'  \1', cff_authors))
+            f.write(cff_parts[1])


### PR DESCRIPTION
Add rewriting authors information into an existing CITATION.cff file. For this to work, a CITATION.cff file needs to already exist. filter.py can then rewrite the authors block according to the contributor list. The rest of the file remains the same (needs to be specified someplace else, ideally, beforehand).